### PR TITLE
fix: modified curl commands for X-5 UAT

### DIFF
--- a/docs/uat/X5_Evidence_Attachment_UAT_Runbook.md
+++ b/docs/uat/X5_Evidence_Attachment_UAT_Runbook.md
@@ -64,6 +64,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-001",
+    "request_id": "req-001",
     "task_type": "echo",
     "payload": {
       "text": "hello uat"
@@ -75,7 +76,7 @@ Verify:
 
 - HTTP 200
 - `request_id` present
-- `executed_at` present
+- `timestamp` present (server-generated execution timestamp)
 - `result` present
 
 ---
@@ -87,6 +88,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-002",
+    "request_id": "req-002",
     "task_type": "echo",
     "payload": {
       "text": "evidence test"
@@ -111,6 +113,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-003",
+    "request_id": "req-003",
     "task_type": "non_existing_task",
     "payload": {}
   }' | jq
@@ -132,6 +135,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-004",
+    "request_id": "req-004",
     "task_type": "echo"
   }' | jq
 ```
@@ -150,6 +154,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-005",
+    "request_id": "req-005",
     "task_type": "echo",
     "payload": {
       "text": "determinism"
@@ -162,6 +167,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "uat-006",
+    "request_id": "req-006",
     "task_type": "echo",
     "payload": {
       "text": "determinism"
@@ -172,8 +178,8 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
 Compare:
 
 ```bash
-jq 'del(.request_id, .executed_at)' r1.json > c1.json
-jq 'del(.request_id, .executed_at)' r2.json > c2.json
+jq 'del(.trace_id, .timestamp, .execution_time_ms)' r1.json > c1.json
+jq 'del(.trace_id, .timestamp, .execution_time_ms)' r2.json > c2.json
 diff c1.json c2.json
 ```
 
@@ -207,6 +213,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "session-A",
+    "request_id": "req-session-A",
     "task_type": "echo",
     "payload": {
       "text": "A"
@@ -219,6 +226,7 @@ curl -s -X POST http://127.0.0.1:8000/invoke \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "session-B",
+    "request_id": "req-session-B",
     "task_type": "echo",
     "payload": {
       "text": "B"


### PR DESCRIPTION
This pull request updates the `docs/uat/X5_Evidence_Attachment_UAT_Runbook.md` to reflect changes in the API request and response structure for UAT scenarios. The main focus is on adding the `request_id` field to all request examples and updating the expected response fields and comparison logic to use the new structure.

**API Request Updates:**
* Added the `"request_id"` field to all example request payloads to demonstrate its required presence in API calls. [[1]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR67) [[2]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR91) [[3]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR116) [[4]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR138) [[5]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR157) [[6]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR170) [[7]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR216) [[8]](diffhunk://#diff-2615ef9e03acb3645517eb47e78e14edc69fe8415227323210a252eaee5efbacR229)

**API Response & Verification Updates:**
* Updated the verification checklist to expect a `timestamp` field (server-generated execution timestamp) instead of `executed_at`, and clarified the presence of `request_id` and `result`.
* Modified the comparison instructions to exclude `trace_id`, `timestamp`, and `execution_time_ms` from diff checks, instead of the previous `request_id` and `executed_at`.