### PR TITLE
docs(adr): ADR-0007 — External Client Integration via Integration Boundary

### DIFF
--- a/docs/adr/adr-0007.md
+++ b/docs/adr/adr-0007.md
@@ -1,0 +1,221 @@
+# ADR-0007 — External Client Integration via Integration Boundary
+
+## Status
+Proposed
+
+## Date
+2026-04-25
+
+## Context
+
+The RAGfish ecosystem was designed and documented (ADR-0000 through ADR-0006) under the assumption of a single, self-contained client: **Noesis Noema**, a closed, on-device, offline-first private RAG application. The Constitution (ADR-0000), the Architecture Constitution (ADR-0004), the Client-side Routing principle (ADR-0005), and the Contract Lock (ADR-0006) all implicitly treat "Client" as a single, internal artifact governed end-to-end by RAGfish governance.
+
+Subsequently, an adjacent project named `trader-ai` emerged. It is a local-first AI trading assistant that combines TradingView chart data, the Binance price feed, and Polymarket prediction-market odds, and reasons over them via Anthropic's Claude CLI invoked through MCP. By construction, `trader-ai`:
+
+- Touches several external SaaS providers (TradingView, Binance, Polymarket).
+- Depends on a remote, cloud-hosted LLM (Claude API).
+- Operates in a domain (financial market analysis) that the Noema Constitution did not anticipate.
+- Is geographically constrained on at least one of its venues (Polymarket geoblock, see the project's README for the operational status entry).
+
+Two integration paths are conceivable:
+
+1. **Absorption**: fold `trader-ai` into the NoesisNoema client and treat it as another internal feature.
+2. **Federation**: keep `trader-ai` as an independent client and expose NoesisNoema's RAG runtime as a reusable, externally-callable component, importable by other clients.
+
+Absorption is **rejected**. It would conflict with several core principles:
+
+- Constitutional Constraint #6 (Model Neutrality) — silent or implicit reliance on a remote model.
+- Constitutional Anti-Pattern #2 (Silent Model Switching) — mixing local and cloud models inside one client.
+- ADR-0001's "private, on-device" identity — `trader-ai`'s data flows are not on-device.
+- The Constitution's "no cloud, no SaaS" implicit identity statement.
+
+The result of absorption would be NoesisNoema slowly losing its identity as a closed, private RAG runtime. That outcome is unacceptable.
+
+Federation is the correct shape. It preserves NoesisNoema's identity while allowing the broader RAGfish ecosystem to be **used** by other clients that have their own decision authority and their own constitutional posture (which may or may not match RAGfish's).
+
+This ADR formalises that federation.
+
+---
+
+## Decision
+
+### 1. NoesisNoema as a Reusable Private RAG Runtime
+
+NoesisNoema is, in addition to being a standalone macOS / iOS application, a **reusable private RAG runtime**. It exposes its core capabilities (knowledge retrieval over RAGpacks, local LLM inference via llama.cpp, query-time policy evaluation) through a well-defined surface that can be consumed by other clients.
+
+The exact shape of that surface (Swift library, local IPC, HTTP API, or a combination) is **not** decided by this ADR. It is the subject of a separate, follow-up EPIC. This ADR only establishes that the surface exists and what invariants it must preserve.
+
+### 2. Integration Boundary
+
+A new architectural concept is introduced: the **Integration Boundary**.
+
+The Integration Boundary sits **outside** the existing Invocation Boundary (ADR-0006, `docs/contracts/invocation-boundary.md`) and governs the contract between NoesisNoema and any **External Client**.
+
+```
+[ External Client ]                    [ NoesisNoema (Internal Client + Execution + Knowledge) ]
+        │                                              │
+        │ ──── Integration Boundary ──────────────► │  (this ADR)
+                                                       │
+                                                       │ ──── Invocation Boundary ────► (ADR-0006)
+                                                       │             │
+                                                       │             ▼
+                                                       │     [ Execution Layer ]
+                                                       │             │
+                                                       │             ▼
+                                                       │     [ Knowledge Layer ]
+```
+
+The Invocation Boundary is **not modified** by this ADR. It continues to govern the internal flow Client → Execution → Knowledge. The Integration Boundary is **new** and governs the flow External Client → NoesisNoema.
+
+### 3. External Client — Definition
+
+An **External Client** is any software artifact that:
+
+- Originates outside NoesisNoema's codebase and governance.
+- Holds its own decision authority for its own domain.
+- Calls into NoesisNoema as a service to obtain knowledge retrieval and / or inference.
+
+Examples:
+
+- `trader-ai` is an External Client whose domain is financial-market analysis.
+- A future research notebook tool that uses NoesisNoema for literature search would be an External Client.
+- A future iOS Shortcut or Apple Intelligence extension that consults RAGpacks via NoesisNoema would be an External Client.
+
+### 4. Invariants Required of External Clients
+
+An External Client crossing the Integration Boundary into NoesisNoema MUST:
+
+1. **Hold its own Decision authority.** The External Client decides *whether* and *when* to call NoesisNoema. NoesisNoema does not solicit calls.
+2. **Issue an explicit, structured request** that conforms to the surface contract (to be specified by the follow-up EPIC). No implicit invocation.
+3. **Carry its own human-accountability story.** Constitutional Constraint #1 (Explicit Invocation Only) and #4 (Human Override Authority) apply within the External Client's own scope. NoesisNoema is not a human-accountability proxy.
+4. **Not assume NoesisNoema state across calls.** The Integration Boundary is, like the Invocation Boundary, stateless from NoesisNoema's perspective. Any session-level continuity is the External Client's responsibility.
+5. **Not embed NoesisNoema decision logic.** Routing, policy, and authority decisions inside NoesisNoema remain inside NoesisNoema. The External Client may pass *constraints* (privacy_scope, latency expectations, etc.) but may not override internal routing.
+
+### 5. Invariants NoesisNoema Preserves Across the Integration Boundary
+
+NoesisNoema, when called by an External Client, MUST:
+
+1. **Preserve all Internal Client invariants.** Everything ADR-0000 through ADR-0006 says about Client / Execution / Knowledge separation continues to hold *inside* NoesisNoema, regardless of who called.
+2. **Refuse to mutate persistent state without consent.** Constitutional Constraint #5 (State Mutation Consent) applies. RAGpack imports, model updates, etc. driven by an External Client require the same explicit consent as user-driven imports.
+3. **Surface routing decisions, not hide them.** When NoesisNoema services a federated request, the routing trace and execution metadata are returned alongside the answer (per `docs/contracts/api-schema.md`'s `RoutingDecision` / `ExecutionMetadata`). The External Client must be *able* to inspect what happened.
+4. **Refuse cross-client memory injection.** RAGpacks, conversation history, and any session memory remain scoped to a specific user / device boundary. NoesisNoema does not silently mix data across External Clients (Constitutional Anti-Pattern #4).
+5. **Apply the Constitution to itself, not to the caller.** NoesisNoema does not police whether the External Client itself is constitution-compliant. It only ensures that *its own* behaviour, when invoked, remains compliant.
+
+### 6. What This ADR Does NOT Do
+
+This ADR explicitly does **not**:
+
+- Modify ADR-0000 (Constitution).
+- Modify ADR-0004 (Architecture Constitution).
+- Modify ADR-0005 (Client-side Routing).
+- Modify ADR-0006 (Contract Lock) or any of the four locked contracts.
+- Specify the wire format or transport of the Integration Boundary surface.
+- Place `trader-ai` (or any other External Client) under RAGfish governance.
+- Promise a specific timeline for the surface implementation.
+
+The Constitution remains the supreme governing document for NoesisNoema. External Clients are *outside* its scope by definition.
+
+### 7. trader-ai's Position
+
+`trader-ai` is, as of this ADR, the first identified External Client.
+
+- It remains in its own repository, under its own governance.
+- It is free to depend on cloud LLMs, external SaaS data sources, and any other architectural choices that suit its domain — those choices are not RAGfish's concern.
+- Its eventual integration into NoesisNoema goes through the Integration Boundary, not through absorption.
+- The integration is **future work**. NoesisNoema's 2025 roadmap (EPIC4 completion and remaining sub-issues) proceeds first, on the assumption that no External Client exists yet. The Integration Boundary's concrete surface is opened only after NoesisNoema's internal architecture is stable.
+
+---
+
+## Rationale
+
+### Why Federation, Not Absorption
+
+Architectural identity is fragile. A system that says "we are a closed, private, on-device RAG runtime" loses that identity the moment it absorbs a feature whose nature is "we call cloud APIs against external SaaS data". Even if the absorbed feature is gated behind a flag, the cognitive contract with users and contributors is broken: nobody can describe NoesisNoema in one sentence anymore.
+
+Federation preserves the one-sentence description. NoesisNoema is what it always was. `trader-ai` is what *it* is. The two communicate through a documented, inspectable boundary.
+
+### Why an Explicit New Boundary, Not Just "An API"
+
+ADR-0006 locked four contracts at v1.0.0 because implicit boundaries drift under iteration pressure. The Integration Boundary is exposed to the same risk — perhaps more so, because external clients vary more widely than internal layers do.
+
+By naming the boundary, requiring it to be specified in `docs/contracts/` (in a follow-up document, not in this ADR), and binding it to a set of explicit invariants, the ADR ensures that the boundary is governed with the same rigor as the existing Invocation Boundary.
+
+### Why Now
+
+Three triggers converged:
+
+1. `trader-ai` exists today and is operationally complete (as a reference implementation, see its README's Operational Status section). The integration question can no longer be deferred without leaving `trader-ai` ungoverned in the RAGfish ecosystem.
+2. NoesisNoema's EPIC4 (Routing & Hybrid Execution) is the last major architectural work before the codebase stabilises. Adding the Integration Boundary concept *before* EPIC4 finishes lets EPIC4's design account for it.
+3. The repository has just been audited (ADR-0000 through ADR-0006 read in order, contracts read in order). This is the right moment to record what was found to be missing.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Identity preservation.** NoesisNoema remains describable as "private, offline, on-device RAG."
+- **Reusability proof-point.** `trader-ai` becomes the first concrete demonstration that the Noema runtime is reusable, which validates the Architecture Constitution's emphasis on layer separation.
+- **Risk isolation.** External risks (geo-restrictions, third-party SaaS outages, cloud-LLM ToS changes) accrue to External Clients, not to NoesisNoema's core.
+- **Governance scalability.** Future External Clients (research tools, OS-level integrations, etc.) can be onboarded against a stable boundary contract instead of negotiating ad-hoc.
+
+### Trade-offs
+
+- **API surface design becomes a first-class concern.** A separate EPIC must specify the Integration Boundary's wire shape, versioning policy, authentication model, and error semantics. This is real work that does not exist today.
+- **`trader-ai`'s integration is delayed.** It cannot federate until both (a) this ADR is accepted and (b) the surface EPIC ships. In the interim, `trader-ai` operates fully standalone.
+- **Two boundary concepts to maintain.** Documentation and onboarding now have to explain Invocation Boundary *and* Integration Boundary. Some readers will conflate them; this ADR's diagram is the canonical disambiguation.
+
+### Mitigations
+
+- The Integration Boundary surface is initially scoped to the minimum needed for `trader-ai`'s use case (RAGpack-backed retrieval over a structured query). Versioning starts at v0.x to signal that the surface is not yet locked.
+- The follow-up EPIC produces a dedicated `docs/contracts/integration-boundary.md` document, parallel in form to `docs/contracts/invocation-boundary.md`, so the two are easy to compare.
+- ADR-0007 itself is the "explanation of last resort" — readers confused about which boundary applies should be directed here.
+
+---
+
+## Verification
+
+This ADR is considered *successfully implemented* when:
+
+1. `docs/contracts/integration-boundary.md` exists and is referenced from this ADR.
+2. NoesisNoema exposes a documented surface that satisfies the invariants in sections 4 and 5 of this ADR.
+3. `trader-ai` (or another External Client) demonstrably uses that surface for at least one concrete use case.
+4. A reader who knows ADR-0006 can read the new Integration Boundary contract and recognise its structural parallel without further explanation.
+
+This ADR is considered *failed* if any of the following occur:
+
+1. The Integration Boundary becomes a back-channel for bypassing the Invocation Boundary.
+2. External Clients accumulate decision authority over NoesisNoema's internal routing.
+3. NoesisNoema starts depending on External Clients (any directional reversal of the federation).
+4. The boundary's surface drifts informally, in the way ADR-0006 was created to prevent.
+
+---
+
+## Related ADRs
+
+- **ADR-0000** — Human Sovereignty Principle. Governs both sides of the Integration Boundary, but separately.
+- **ADR-0004** — Architecture Constitution. The three-layer model continues to apply *within* NoesisNoema; the Integration Boundary is layered outside it.
+- **ADR-0005** — Client-side Routing. NoesisNoema's internal routing is unchanged; External Clients have their own routing in their own scope.
+- **ADR-0006** — Contract Lock. The four locked contracts are not modified. A new contract document (`integration-boundary.md`) will be added in the follow-up EPIC, governed by the same change policy.
+
+---
+
+## Open Questions
+
+The following are explicitly left open for the follow-up EPIC and are *not* decided by this ADR:
+
+1. **Surface form**: Swift library? Local IPC (XPC, Unix socket)? Loopback HTTP? Some combination?
+2. **Authentication and authorisation** between External Client and NoesisNoema. Constitutional Constraint #1 (Explicit Invocation Only) suggests at minimum that calls must be attributable.
+3. **RAGpack ownership semantics** when an External Client wants to provide its own packs versus consume the user's existing packs.
+4. **Streaming vs. one-shot** answer delivery across the boundary.
+5. **Error-model translation** between NoesisNoema's `ExecutionError` (per `docs/contracts/api-schema.md`) and whatever the External Client expects.
+6. **Telemetry and tracing** — whether `RoutingDecision` and `ExecutionMetadata` flow back across the Integration Boundary verbatim, or in a redacted form.
+
+These will be answered when the follow-up EPIC is opened.
+
+---
+
+**Authors**: Taka, Claude
+**Reviewers**: Architecture review pending
+**Supersedes**: None
+**Superseded by**: None


### PR DESCRIPTION
## Summary

Adds **ADR-0007 — External Client Integration via Integration Boundary**.

This ADR formalises the relationship between NoesisNoema (the canonical RAGfish client) and external projects that may want to *call* NoesisNoema as a reusable private RAG runtime — most immediately, `trader-ai`.

## Why this ADR exists

The first seven ADRs were written under the implicit assumption that NoesisNoema is the *only* client. That assumption was correct at the time. It is no longer correct.

`trader-ai` is now operationally complete (as a reference implementation) and lives in a separate repository with its own goals (TradingView + Binance + Polymarket + Claude CLI). Two integration paths were possible:

1. **Absorb** `trader-ai` into NoesisNoema.
2. **Federate** — keep `trader-ai` independent and let it consume NoesisNoema through a well-defined boundary.

Absorption is rejected in this ADR. It would dilute NoesisNoema's identity (the Constitution's "private, offline, on-device" stance) by importing cloud-LLM and SaaS dependencies. Federation is the correct shape and is what this ADR establishes.

## Key concepts introduced

- **Integration Boundary** — a new boundary sitting *outside* the existing Invocation Boundary (ADR-0006). It governs External Client → NoesisNoema. It does **not** modify any existing boundary.
- **External Client** — a defined term. Any system that holds its own decision authority and calls NoesisNoema as a service. `trader-ai` is the first one.
- **NoesisNoema as Reusable Private RAG Runtime** — formal acknowledgement that NoesisNoema's role is dual: standalone macOS/iOS app, *and* a callable runtime.

## Invariants the ADR pins down

For External Clients (section 4): own decision authority, explicit invocation, own human accountability, statelessness, no internal-routing override.

For NoesisNoema (section 5): preserve all internal layer separation, refuse silent state mutation, surface routing decisions, refuse cross-client memory mixing, apply the Constitution to itself but not to the caller.

## What this ADR explicitly does NOT do

- Modify ADR-0000, ADR-0004, ADR-0005, or ADR-0006.
- Touch any of the four locked contracts (v1.0.0).
- Specify the wire format / transport of the Integration Boundary.
- Bring `trader-ai` under RAGfish governance.
- Promise a timeline.

The actual surface (Swift library? local IPC? loopback HTTP?) is left to a follow-up EPIC. This ADR only says the surface exists and what invariants bind it.

## Sequencing

> NoesisNoema's 2025 roadmap (EPIC4 + remaining sub-issues) proceeds first.
> Integration is future work.

This ADR being merged does **not** unblock implementation. It pre-positions the architectural framing so that EPIC4 can be designed with it in mind, but EPIC4 itself remains the immediate priority.

## Status

`Proposed`. Awaiting review and an explicit `Accepted` stamp from the governance authority (Taka) before any implementation work proceeds. Per the convention used by ADR-0000 through ADR-0006, that stamp is what promotes the ADR from `Proposed` to `Accepted`.

## Review notes for the reviewer

Things to specifically check:

1. The diagram in section 2 — does the layering match your mental model?
2. Section 4's five external invariants — anything missing? Anything over-constraining?
3. Section 5's five internal invariants — anything missing? Anything that would impede legitimate integration?
4. Section 7's positioning of `trader-ai` as "the first External Client" — accurate?
5. The Open Questions list (six items) — anything that should be *closed* here rather than deferred?

If the answer to any of these is "no, change it", I'll iterate on this branch before the Accepted stamp.

## Related work

- All seven prior ADRs are referenced in the body.
- A future PR will add `docs/contracts/integration-boundary.md` once this ADR is Accepted; that will be the actual wire-level contract.
- A future PR will update the architecture diagram (`docs/architecture/architecture-standalone.puml`) to show the External Client position.
- `trader-ai`'s repository will eventually link back to this ADR from its README's "Operational status" / "Integration" section.
